### PR TITLE
Apply code review suggestions from matklad

### DIFF
--- a/devx-cmd/src/error.rs
+++ b/devx-cmd/src/error.rs
@@ -1,4 +1,4 @@
-use crate::{ChildProcess, Cmd};
+use crate::{Child, Cmd};
 use std::fmt;
 
 /// Shortcut for `Result<T, devx_cmd::Error>`
@@ -12,13 +12,13 @@ impl std::error::Error for Error {}
 
 pub(crate) trait Context<T> {
     fn cmd_context(self, cmd: &Cmd) -> Result<T>;
-    fn proc_context(self, proc: &ChildProcess) -> Result<T>;
+    fn proc_context(self, proc: &Child) -> Result<T>;
 }
 impl<T, E: fmt::Display> Context<T> for Result<T, E> {
     fn cmd_context(self, cmd: &Cmd) -> Result<T> {
         self.map_err(|err| Error::cmd(cmd, &err))
     }
-    fn proc_context(self, proc: &ChildProcess) -> Result<T> {
+    fn proc_context(self, proc: &Child) -> Result<T> {
         self.map_err(|err| Error::proc(proc, &err))
     }
 }
@@ -35,7 +35,7 @@ impl Error {
     fn cmd(cmd: &Cmd, message: &dyn fmt::Display) -> Self {
         Self::new(format!("{}\nCommand: {}", message, cmd), cmd.0.echo_err)
     }
-    pub(crate) fn proc(proc: &ChildProcess, message: &dyn fmt::Display) -> Self {
+    pub(crate) fn proc(proc: &Child, message: &dyn fmt::Display) -> Self {
         Self::new(
             format!("{}\nProcess: {}", message, proc),
             proc.cmd.0.echo_err,

--- a/devx-cmd/src/lib.rs
+++ b/devx-cmd/src/lib.rs
@@ -280,7 +280,7 @@ impl Cmd {
             .map(Self::new)
     }
 
-    /// Returns a command builder for the given `bin_name` only if the this
+    /// Returns a command builder for the given `bin_name` only if this
     /// `bin_name` is accessible trough `PATH` env variable, otherwise returns `None`
     pub fn lookup_in_path(bin_name: &str) -> Option<Self> {
         let paths = env::var_os("PATH").unwrap_or_default();
@@ -480,7 +480,7 @@ impl Cmd {
 
 /// Wraps [`std::process::Child`], kills and waits for the process on [`Drop`].
 /// It will log the fact that [`std::process::Child::kill`] was called in [`Drop`].
-/// You should use wait for the process to finish with any of the available
+/// You should use [`Child::wait`] for the process to finish with any of the available
 /// methods if you want to handle the error, otherwise it will be ignored.
 ///
 /// Beware that [`Child`] holds an invariant that is not propagated to the
@@ -488,6 +488,7 @@ impl Cmd {
 /// [`Cmd::spawn_piped`], then any methods that read the child's `stdout` will panic.
 ///
 /// [`Child`]: struct.Child.html
+/// [`Child::wait`]: struct.Child.html#method.wait
 /// [`Cmd::spawn_piped`]: struct.Cmd.html#method.spawn_piped
 /// [`Drop`]: https://doc.rust-lang.org/std/ops/trait.Drop.html
 /// [`std::process::Child`]: https://doc.rust-lang.org/std/process/struct.Child.html


### PR DESCRIPTION
See the review here: https://github.com/matklad/devx/commit/dd38a435ccda5af003d7bf2f722d945f859b6fc8
A bit of elaboration:
`struct Cmd(Arc<CmdShared>);` is basically a thin clone-on-write setup. This is useful since `Child` holds the reference to the `Cmd` that created it (and I wanted to avoid borrowing). With `Arc::make_mut` it is extremely easy to have this clone-on-write setup, I would like to preserve it.

`error_cmd: bool` field is used in `error.rs` file

Some points I haven't gone for:
```rust
// Have this
fn stdin(impl Into<BinOrUtf8>) {}
// instead of
fn stdin(impl Into<String>) {}
fn stdin_bytes(Vec<u8>) {}
```
`BInOrUtf8` type is an implementation detail, but otherwise having `impl Into<BinOrUtf8>` is not that flexible as `impl Into<String>`, since this trait is open-ended, but when implementing `From<T> for BInOrUtf8` we have to manually enumerate all possible types `T` (we cannot use T: Into<String> and have a separate impl for `Vec<u8>` due to trait coherence issues)

Didn't know about `arg((a, b))` trick in `pico-args`, but adds one more layer of parens :d

