### PR TITLE
Make cargo-deny-check job more strict

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,14 +23,20 @@ jobs:
   # Audit Rust vulnerabilities, licenses, duplicated deps as specified in `deny.toml`
   cargo-deny-check:
     runs-on: ubuntu-latest
-    # This job is optional because:
-    # - Sudden vulnerability announcement that touches us will break all ci runs
-    # - cargo-deny is mostly useful for the maintainers, we want contributors
-    #   to avoid spending much time learning this tool if this job doesn't pass
-    continue-on-error: true
+    strategy:
+      matrix:
+        checks:
+          - advisories
+          - bans licenses sources
+
+    # Prevent sudden announcement of a new advisory from failing ci:
+    continue-on-error: ${{ matrix.checks == 'advisories' }}
+
     steps:
       - uses: actions/checkout@v2
       - uses: EmbarkStudios/cargo-deny-action@v1
+        with:
+          command: check ${{ matrix.checks }}
 
   rust-lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
As `anelson` has mentionned: why not making only advisories check optional.
Indeed this LGTM

bors r+