### PR TITLE
Replace `std::fs` with `fs-err` crate for much better error messages sake

### DIFF
--- a/devx-pre-commit/Cargo.toml
+++ b/devx-pre-commit/Cargo.toml
@@ -20,3 +20,4 @@ description = """
 [dependencies]
 devx-cmd = { version = "0.2.0", path = "../devx-cmd" }
 anyhow = "1.0"
+fs-err = "2.3"

--- a/devx-pre-commit/src/lib.rs
+++ b/devx-pre-commit/src/lib.rs
@@ -68,11 +68,11 @@
 // something they couldn't detect (e.g. unsafe added via macro expansion, etc).
 #![forbid(unsafe_code)]
 
+use fs_err as fs;
 use std::{
     collections::HashSet,
     env::{self, consts},
     ffi::OsStr,
-    fs,
     ops::Deref,
     path::{Path, PathBuf},
 };


### PR DESCRIPTION
bors d=anelson